### PR TITLE
PAC not rendering in icons fix

### DIFF
--- a/lua/ps2/client/icons/cl_haticon_prerender.lua
+++ b/lua/ps2/client/icons/cl_haticon_prerender.lua
@@ -92,6 +92,8 @@ local function PaintHatIcon(itemClass)
 		pac.HookEntityRender( entity, v )
 	end
 	
+	pac.RenderOverride(entity, "update", true)
+	
 	if not petModel then
 		local viewInfo = itemClass.iconInfo.shop.iconViewInfo
 		entity:SetModel( plyModel )


### PR DESCRIPTION
This appears to fix the icons rendering w/o their PAC accessories w/o needing to downgrade PAC3