### PR TITLE
Tiny changes to correct a couple small issues.

### DIFF
--- a/lua/ps2/client/tabs/inventory_tab/cl_dpointshopinventorypanel.lua
+++ b/lua/ps2/client/tabs/inventory_tab/cl_dpointshopinventorypanel.lua
@@ -219,7 +219,7 @@ function PANEL:PopulateSlots( )
             if itemInThisSlot and previousSlot then
                 -- calls slot's function directly to avoid infinite loops
                 local prevCanHoldItem = Pointshop2.EquipmentSlotLookup[previousSlot]
-                if not prevCanHoldItem() then
+                if not prevCanHoldItem(item) then
                     return false
                 end
             end

--- a/lua/ps2/modules/pointshop2/points_over_time/cl_DPointsOverTimeConfigurator.lua
+++ b/lua/ps2/modules/pointshop2/points_over_time/cl_DPointsOverTimeConfigurator.lua
@@ -269,15 +269,15 @@ function PANEL:SetData( data )
 end
 
 function PANEL:Verify( settings )
-	if settings["PointsOverTime.Delay"] < 1 then
+	if tonumber(settings["PointsOverTime.Delay"]) < 1 then
 		return false, "Delay has to be greater than 1"
 	end
 
-	if settings["PointsOverTime.Points"] > 20000000 then
+	if tonumber(settings["PointsOverTime.Points"]) > 20000000 then
 		return false, "Points amount is too large"
 	end
 
-	if settings["PointsOverTime.Points"] < 0 then
+	if tonumber(settings["PointsOverTime.Points"]) < 0 then
 		return false, "Points amount need to be >0"
 	end
 


### PR DESCRIPTION
cl_dpointshopinventorypanel.lua:
Added missing parameter, without this users can equip multiple hats at once per their session.
DPointsOverTimeConfigurator.lua:
Forced numeric conversion on config values before comparing due to an issue I kept getting with no perceivable reason.