### PR TITLE
Prop Hunt: Integration Fixes for Prop Hunt: X gamemode

### DIFF
--- a/lua/ps2/modules/prophunt_integration/sv_ProphuntHooks.lua
+++ b/lua/ps2/modules/prophunt_integration/sv_ProphuntHooks.lua
@@ -89,7 +89,11 @@ function Pointshop2.PropHunt.OnPropKilled( victim, inflictor, attacker )
 		attacker:PS2_AddStandardPoints( S("Kills.HunterKillsProp"), "Killed Prop" )
 	end
 end
-hook.Add( "PS2_PH_PropKilled", "PH_PropKilled", Pointshop2.PropHunt.OnPropKilled )
+if PHX and PHX ~= nil then
+	hook.Add("PH_OnPropKilled", "PH_PS2_PropKilled", Pointshop2.PropHunt.OnPropKilled ) -- We'll use from provided PH:X hook instead.
+else
+	hook.Add( "PS2_PH_PropKilled", "PH_PropKilled", Pointshop2.PropHunt.OnPropKilled )
+end
 
 local function installHooks( )
 	GAMEMODE.OriginalSetRoundResult = GAMEMODE.OriginalSetRoundResult or GAMEMODE.SetRoundResult -- need to use this as fretta resets timer before OnRoundResult

--- a/lua/ps2/modules/prophunt_integration/sv_propHuntPropHook.lua
+++ b/lua/ps2/modules/prophunt_integration/sv_propHuntPropHook.lua
@@ -1,4 +1,6 @@
 local function hookProp()
+	if PHX and PHX ~= nil then return end
+	
     local ENT = scripted_ents.GetStored( 'ph_prop' )
     -- Called when we take damge
     function ENT:OnTakeDamage(dmg)


### PR DESCRIPTION
This will use original PH:X (Previously was Prop Hunt: Enhanced) `PH_OnPropKilled` hooks that will get called once the Prop is Killed. Modifying the `ph_prop` entity may cause some features & it's functions e.g Freeze Cam, No Team Prop Kill and other features are not functioning. This pull request will fixed it.

Also, you may also improve the code if you'd like to.