### PR TITLE
Added null check for potential breaking point.

### DIFF
--- a/lua/ps2/shared/sh_0_pointshop2.lua
+++ b/lua/ps2/shared/sh_0_pointshop2.lua
@@ -149,9 +149,11 @@ end
 function Pointshop2.GetCreatorControlForClass( itemClass )
 	local base = itemClass.super.className
 	for _, mod in pairs( Pointshop2.Modules ) do
-		for _, itemInfo in pairs( mod.Blueprints ) do
-			if itemInfo.base == base then
-				return itemInfo.creator, itemInfo.noModal
+		if mod.Blueprints then
+			for _, itemInfo in pairs( mod.Blueprints ) do
+				if itemInfo.base == base then
+					return itemInfo.creator, itemInfo.noModal
+				end
 			end
 		end
 	end


### PR DESCRIPTION
If you use a module that doesnt have blueprints like this one: https://github.com/Instinkt-Servers/PS2SimpleStattrak it can break the entire shop. The mentioned one loads before permaweapons, erroring, and then disabling things like editing weapons. This can and will break with *every* module that doesnt specify Blueprints. Thus adding a nil check here to prevent it from happening with the named and any potential unnamed module(s).